### PR TITLE
Reduce logos-with-text sizes (-323B -322B)

### DIFF
--- a/logo_dark.svg
+++ b/logo_dark.svg
@@ -1,115 +1,151 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   xml:space="preserve"
-   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
-   viewBox="663.38 37.57 2087.006 903.71997"
-   id="svg22"
-   sodipodi:docname="logo_dark.svg"
-   width="2087.0059"
-   height="903.71997"
-   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><defs
-   id="defs26"><rect
-     x="713.02588"
-     y="-304.32538"
-     width="3615.2336"
-     height="1864.7544"
-     id="rect14663" /><rect
-     x="972.073"
-     y="151.15895"
-     width="2140.9646"
-     height="684.86273"
-     id="rect447" /><rect
-     x="897.0401"
-     y="217.45384"
-     width="837.72321"
-     height="631.59924"
-     id="rect435" /><rect
-     x="825.67834"
-     y="157.61452"
-     width="1496.2448"
-     height="861.45544"
-     id="rect429" /><rect
-     x="798.3819"
-     y="-42.157242"
-     width="2236.0837"
-     height="945.90723"
-     id="rect315" /><rect
-     x="661.30237"
-     y="48.087799"
-     width="769.15619"
-     height="828.46844"
-     id="rect309" /></defs><sodipodi:namedview
-   id="namedview24"
-   pagecolor="#ffffff"
-   bordercolor="#000000"
-   borderopacity="0.25"
-   inkscape:showpageshadow="2"
-   inkscape:pageopacity="0.0"
-   inkscape:pagecheckerboard="0"
-   inkscape:deskcolor="#d1d1d1"
-   showgrid="false"
-   inkscape:zoom="0.28409405"
-   inkscape:cx="1904.2989"
-   inkscape:cy="633.59299"
-   inkscape:window-width="1908"
-   inkscape:window-height="2075"
-   inkscape:window-x="26"
-   inkscape:window-y="23"
-   inkscape:window-maximized="0"
-   inkscape:current-layer="svg22" />     <g
-   transform="translate(-31352.726,-1817.2547)"
-   id="g20">                  <g
-   transform="translate(31062.7,-20.8972)"
-   id="g18">             <g
-   transform="translate(-130.173,0.00185558)"
-   id="g4">                 <path
-   d="m 1083.58,1875.72 551.48,318.4 c 14.74,8.51 23.82,24.25 23.82,41.27 0,29.59 0,76.35 0,105.94 0,8.51 -2.27,16.7 -6.38,23.83 0,0 -437.8,-252.76 -545.3,-314.83 -14.62,-8.44 -23.62,-24.04 -23.62,-40.92 0,-45.91 0,-133.69 0,-133.69 z"
-   style="fill:#706bc8"
-   id="path2" />             </g>             <g
-   transform="translate(-130.173,0.00185558)"
-   id="g8">                 <path
-   d="m 1635.26,2604.84 c 14.62,8.44 23.62,24.03 23.62,40.91 0,45.92 0,133.69 0,133.69 l -551.47,-318.39 c -14.75,-8.52 -23.83,-24.25 -23.83,-41.27 0,-29.59 0,-76.36 0,-105.94 0,-8.52 2.27,-16.71 6.38,-23.83 0,0 437.8,252.76 545.3,314.83 z"
-   style="fill:#55c5e4"
-   id="path6" />             </g>             <g
-   transform="translate(216.062,984.098)"
-   id="g12">                 <path
-   d="m 790.407,1432.56 c -5.193,2.99 -9.69,7.34 -12.898,12.9 -9.647,16.7 -4.036,38.3 12.495,48.13 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.24 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.983 9.5,-7.286 12.65,-12.756 9.65,-16.708 4.04,-38.3 -12.49,-48.137 h 0.01 l 28.82,16.642 c 14.75,8.513 23.83,24.246 23.83,41.273 0,29.588 0,76.348 0,105.938 0,17.03 -9.08,32.76 -23.83,41.27 l -29.63,17.11 0.4,-0.26 z"
-   style="fill:#84ddea"
-   id="path10" />             </g>             <g
-   transform="translate(216.062,984.098)"
-   id="g16">                 <path
-   d="m 790.407,1686.24 c -5.193,2.99 -9.69,7.34 -12.898,12.89 -9.647,16.71 -4.036,38.3 12.495,48.14 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.25 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.99 9.5,-7.29 12.65,-12.76 9.65,-16.71 4.04,-38.3 -12.49,-48.14 h 0.01 l 28.82,16.65 c 14.75,8.51 23.83,24.24 23.83,41.27 0,29.59 0,76.35 0,105.94 0,17.02 -9.08,32.76 -23.83,41.27 l -29.63,17.1 0.4,-0.25 z"
-   style="fill:#997bc8"
-   id="path14" /></g></g></g> <text
-   xml:space="preserve"
-   transform="translate(663.354,37.565425)"
-   id="text307"
-   style="font-size:4px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect309);display:inline;fill:#006400;stroke:#006400;stroke-width:2.66667" /><g
-   aria-label="Helix"
-   transform="matrix(1.3113898,0,0,1.3113898,142.0244,48.21073)"
-   id="text445"
-   style="font-size:4px;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect447);display:inline;fill:#f0f6fc;stroke:#f0f6fc;stroke-width:2.66687;stroke-opacity:1;fill-opacity:1"><path
-     d="m 1242.0723,515.10828 h -60.4 v -123.2 h -113.2 v 123.2 h -60.4 v -285.6 h 60.4 v 112 h 113.2 v -112 h 60.4 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
-     id="path14794" /><path
-     d="m 1399.272,292.70828 q 30.4,0 52,11.6 22,11.6 34,33.6 12,22 12,54 v 28.8 h -140.8 q 0.8,25.2 14.8,39.6 14.4,14.4 39.6,14.4 21.2,0 38.4,-4 17.2,-4.4 35.6,-13.2 v 46 q -16,8 -34,11.6 -17.6,4 -42.8,4 -32.8,0 -58,-12 -25.2,-12.4 -39.6,-37.2 -14.4,-24.8 -14.4,-62.4 0,-38.4 12.8,-63.6 13.2,-25.6 36.4,-38.4 23.2,-12.8 54,-12.8 z m 0.4,42.4 q -17.2,0 -28.8,11.2 -11.2,11.2 -13.2,34.8 h 83.6 q 0,-13.2 -4.8,-23.6 -4.4,-10.4 -13.6,-16.4 -9.2,-6 -23.2,-6 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
-     id="path14796" /><path
-     d="m 1605.2719,515.10828 h -59.6 v -304 h 59.6 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
-     id="path14798" /><path
-     d="m 1727.272,296.70828 v 218.4 h -59.6 v -218.4 z m -29.6,-85.6 q 13.2,0 22.8,6.4 9.6,6 9.6,22.8 0,16.4 -9.6,22.8 -9.6,6.4 -22.8,6.4 -13.6,0 -23.2,-6.4 -9.2,-6.4 -9.2,-22.8 0,-16.8 9.2,-22.8 9.6,-6.4 23.2,-6.4 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
-     id="path14800" /><path
-     d="m 1834.4721,403.50828 -70.4,-106.8 h 67.6 l 42.4,69.6 42.8,-69.6 h 67.6 l -71.2,106.8 74.4,111.6 h -67.6 l -46,-74.8 -46,74.8 h -67.6 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
-     id="path14802" /></g><text
-   xml:space="preserve"
-   transform="translate(663.38,37.570044)"
-   id="text14661"
-   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:997.723px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, @wght=700';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variation-settings:'wght' 700;white-space:pre;shape-inside:url(#rect14663);display:inline;fill:#2a292f;fill-opacity:1;stroke:#2a292f;stroke-width:6.652;stroke-dasharray:none;stroke-opacity:1" /></svg>
+	version="1.1"
+	xml:space="preserve"
+	style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+	viewBox="663.38 37.57 2087.006 903.71997"
+	id="svg22"
+	sodipodi:docname="logo_dark.svg"
+	width="2087.0059"
+	height="903.71997"
+	inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:svg="http://www.w3.org/2000/svg">
+
+<defs id="defs26">
+	<rect
+		x="713.02588"
+		y="-304.32538"
+		width="3615.2336"
+		height="1864.7544"
+		id="rect14663" />
+	<rect
+		x="972.073"
+		y="151.15895"
+		width="2140.9646"
+		height="684.86273"
+		id="rect447" />
+	<rect
+		x="897.0401"
+		y="217.45384"
+		width="837.72321"
+		height="631.59924"
+		id="rect435" />
+	<rect
+		x="825.67834"
+		y="157.61452"
+		width="1496.2448"
+		height="861.45544"
+		id="rect429" />
+	<rect
+		x="798.3819"
+		y="-42.157242"
+		width="2236.0837"
+		height="945.90723"
+		id="rect315" />
+	<rect
+		x="661.30237"
+		y="48.087799"
+		width="769.15619"
+		height="828.46844"
+		id="rect309" />
+</defs>
+<sodipodi:namedview
+	id="namedview24"
+	pagecolor="#ffffff"
+	bordercolor="#000000"
+	borderopacity="0.25"
+	inkscape:showpageshadow="2"
+	inkscape:pageopacity="0.0"
+	inkscape:pagecheckerboard="0"
+	inkscape:deskcolor="#d1d1d1"
+	showgrid="false"
+	inkscape:zoom="0.28409405"
+	inkscape:cx="1904.2989"
+	inkscape:cy="633.59299"
+	inkscape:window-width="1908"
+	inkscape:window-height="2075"
+	inkscape:window-x="26"
+	inkscape:window-y="23"
+	inkscape:window-maximized="0"
+	inkscape:current-layer="svg22" />
+<g
+	transform="translate(-31352.726,-1817.2547)"
+	id="g20">
+	<g
+		transform="translate(31062.7,-20.8972)"
+		id="g18">
+		<g
+			transform="translate(-130.173,0.00185558)"
+			id="g4">
+			<path
+				d="m 1083.58,1875.72 551.48,318.4 c 14.74,8.51 23.82,24.25 23.82,41.27 0,29.59 0,76.35 0,105.94 0,8.51 -2.27,16.7 -6.38,23.83 0,0 -437.8,-252.76 -545.3,-314.83 -14.62,-8.44 -23.62,-24.04 -23.62,-40.92 0,-45.91 0,-133.69 0,-133.69 z"
+				style="fill:#706bc8"
+				id="path2" />
+		</g>
+		<g
+			transform="translate(-130.173,0.00185558)"
+			id="g8">
+			<path
+				d="m 1635.26,2604.84 c 14.62,8.44 23.62,24.03 23.62,40.91 0,45.92 0,133.69 0,133.69 l -551.47,-318.39 c -14.75,-8.52 -23.83,-24.25 -23.83,-41.27 0,-29.59 0,-76.36 0,-105.94 0,-8.52 2.27,-16.71 6.38,-23.83 0,0 437.8,252.76 545.3,314.83 z"
+				style="fill:#55c5e4"
+				id="path6" />
+		</g>
+		<g
+			transform="translate(216.062,984.098)"
+			id="g12">
+			<path
+				d="m 790.407,1432.56 c -5.193,2.99 -9.69,7.34 -12.898,12.9 -9.647,16.7 -4.036,38.3 12.495,48.13 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.24 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.983 9.5,-7.286 12.65,-12.756 9.65,-16.708 4.04,-38.3 -12.49,-48.137 h 0.01 l 28.82,16.642 c 14.75,8.513 23.83,24.246 23.83,41.273 0,29.588 0,76.348 0,105.938 0,17.03 -9.08,32.76 -23.83,41.27 l -29.63,17.11 0.4,-0.26 z"
+				style="fill:#84ddea"
+				id="path10" />
+		</g>
+		<g
+			transform="translate(216.062,984.098)"
+			id="g16">
+			<path
+				d="m 790.407,1686.24 c -5.193,2.99 -9.69,7.34 -12.898,12.89 -9.647,16.71 -4.036,38.3 12.495,48.14 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.25 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.99 9.5,-7.29 12.65,-12.76 9.65,-16.71 4.04,-38.3 -12.49,-48.14 h 0.01 l 28.82,16.65 c 14.75,8.51 23.83,24.24 23.83,41.27 0,29.59 0,76.35 0,105.94 0,17.02 -9.08,32.76 -23.83,41.27 l -29.63,17.1 0.4,-0.25 z"
+				style="fill:#997bc8"
+				id="path14" />
+		</g>
+	</g>
+</g>
+<text
+	xml:space="preserve"
+	transform="translate(663.354,37.565425)"
+	id="text307"
+	style="font-size:4px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect309);display:inline;fill:#006400;stroke:#006400;stroke-width:2.66667" />
+<g
+	aria-label="Helix"
+	transform="matrix(1.3113898,0,0,1.3113898,142.0244,48.21073)"
+	id="text445"
+	style="font-size:4px;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect447);display:inline;fill:#f0f6fc;stroke:#f0f6fc;stroke-width:2.66687;stroke-opacity:1;fill-opacity:1">
+	<path
+		d="m 1242.0723,515.10828 h -60.4 v -123.2 h -113.2 v 123.2 h -60.4 v -285.6 h 60.4 v 112 h 113.2 v -112 h 60.4 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
+		id="path14794" />
+	<path
+		d="m 1399.272,292.70828 q 30.4,0 52,11.6 22,11.6 34,33.6 12,22 12,54 v 28.8 h -140.8 q 0.8,25.2 14.8,39.6 14.4,14.4 39.6,14.4 21.2,0 38.4,-4 17.2,-4.4 35.6,-13.2 v 46 q -16,8 -34,11.6 -17.6,4 -42.8,4 -32.8,0 -58,-12 -25.2,-12.4 -39.6,-37.2 -14.4,-24.8 -14.4,-62.4 0,-38.4 12.8,-63.6 13.2,-25.6 36.4,-38.4 23.2,-12.8 54,-12.8 z m 0.4,42.4 q -17.2,0 -28.8,11.2 -11.2,11.2 -13.2,34.8 h 83.6 q 0,-13.2 -4.8,-23.6 -4.4,-10.4 -13.6,-16.4 -9.2,-6 -23.2,-6 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
+		id="path14796" />
+	<path
+		d="m 1605.2719,515.10828 h -59.6 v -304 h 59.6 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
+		id="path14798" />
+	<path
+		d="m 1727.272,296.70828 v 218.4 h -59.6 v -218.4 z m -29.6,-85.6 q 13.2,0 22.8,6.4 9.6,6 9.6,22.8 0,16.4 -9.6,22.8 -9.6,6.4 -22.8,6.4 -13.6,0 -23.2,-6.4 -9.2,-6.4 -9.2,-22.8 0,-16.8 9.2,-22.8 9.6,-6.4 23.2,-6.4 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
+		id="path14800" />
+	<path
+		d="m 1834.4721,403.50828 -70.4,-106.8 h 67.6 l 42.4,69.6 42.8,-69.6 h 67.6 l -71.2,106.8 74.4,111.6 h -67.6 l -46,-74.8 -46,74.8 h -67.6 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700;stroke:#f0f6fc;stroke-opacity:1;fill:#f0f6fc;fill-opacity:1"
+		id="path14802" />
+</g>
+<text
+	xml:space="preserve"
+	transform="translate(663.38,37.570044)"
+	id="text14661"
+	style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:997.723px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, @wght=700';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variation-settings:'wght' 700;white-space:pre;shape-inside:url(#rect14663);display:inline;fill:#2a292f;fill-opacity:1;stroke:#2a292f;stroke-width:6.652;stroke-dasharray:none;stroke-opacity:1" />
+
+</svg>

--- a/logo_light.svg
+++ b/logo_light.svg
@@ -111,13 +111,11 @@
 		</g>
 	</g>
 </g>
-
 <text
 	xml:space="preserve"
 	transform="translate(663.354,37.565425)"
 	id="text307"
 	style="font-size:4px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect309);display:inline;fill:#006400;stroke:#006400;stroke-width:2.66667" />
-
 <g
 	aria-label="Helix"
 	transform="matrix(1.3113898,0,0,1.3113898,142.0244,48.21073)"
@@ -144,7 +142,6 @@
 		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
 		id="path14802" />
 </g>
-
 <text
 	xml:space="preserve"
 	transform="translate(663.38,37.570044)"

--- a/logo_light.svg
+++ b/logo_light.svg
@@ -1,115 +1,154 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   xml:space="preserve"
-   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
-   viewBox="663.38 37.57 2087.006 903.71997"
-   id="svg22"
-   sodipodi:docname="logo_light.svg"
-   width="2087.0059"
-   height="903.71997"
-   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><defs
-   id="defs26"><rect
-     x="713.02588"
-     y="-304.32538"
-     width="3615.2336"
-     height="1864.7544"
-     id="rect14663" /><rect
-     x="972.073"
-     y="151.15895"
-     width="2140.9646"
-     height="684.86273"
-     id="rect447" /><rect
-     x="897.0401"
-     y="217.45384"
-     width="837.72321"
-     height="631.59924"
-     id="rect435" /><rect
-     x="825.67834"
-     y="157.61452"
-     width="1496.2448"
-     height="861.45544"
-     id="rect429" /><rect
-     x="798.3819"
-     y="-42.157242"
-     width="2236.0837"
-     height="945.90723"
-     id="rect315" /><rect
-     x="661.30237"
-     y="48.087799"
-     width="769.15619"
-     height="828.46844"
-     id="rect309" /></defs><sodipodi:namedview
-   id="namedview24"
-   pagecolor="#ffffff"
-   bordercolor="#000000"
-   borderopacity="0.25"
-   inkscape:showpageshadow="2"
-   inkscape:pageopacity="0.0"
-   inkscape:pagecheckerboard="0"
-   inkscape:deskcolor="#d1d1d1"
-   showgrid="false"
-   inkscape:zoom="0.28409405"
-   inkscape:cx="1904.2989"
-   inkscape:cy="633.59299"
-   inkscape:window-width="1908"
-   inkscape:window-height="2075"
-   inkscape:window-x="26"
-   inkscape:window-y="23"
-   inkscape:window-maximized="0"
-   inkscape:current-layer="svg22" />     <g
-   transform="translate(-31352.726,-1817.2547)"
-   id="g20">                  <g
-   transform="translate(31062.7,-20.8972)"
-   id="g18">             <g
-   transform="translate(-130.173,0.00185558)"
-   id="g4">                 <path
-   d="m 1083.58,1875.72 551.48,318.4 c 14.74,8.51 23.82,24.25 23.82,41.27 0,29.59 0,76.35 0,105.94 0,8.51 -2.27,16.7 -6.38,23.83 0,0 -437.8,-252.76 -545.3,-314.83 -14.62,-8.44 -23.62,-24.04 -23.62,-40.92 0,-45.91 0,-133.69 0,-133.69 z"
-   style="fill:#706bc8"
-   id="path2" />             </g>             <g
-   transform="translate(-130.173,0.00185558)"
-   id="g8">                 <path
-   d="m 1635.26,2604.84 c 14.62,8.44 23.62,24.03 23.62,40.91 0,45.92 0,133.69 0,133.69 l -551.47,-318.39 c -14.75,-8.52 -23.83,-24.25 -23.83,-41.27 0,-29.59 0,-76.36 0,-105.94 0,-8.52 2.27,-16.71 6.38,-23.83 0,0 437.8,252.76 545.3,314.83 z"
-   style="fill:#55c5e4"
-   id="path6" />             </g>             <g
-   transform="translate(216.062,984.098)"
-   id="g12">                 <path
-   d="m 790.407,1432.56 c -5.193,2.99 -9.69,7.34 -12.898,12.9 -9.647,16.7 -4.036,38.3 12.495,48.13 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.24 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.983 9.5,-7.286 12.65,-12.756 9.65,-16.708 4.04,-38.3 -12.49,-48.137 h 0.01 l 28.82,16.642 c 14.75,8.513 23.83,24.246 23.83,41.273 0,29.588 0,76.348 0,105.938 0,17.03 -9.08,32.76 -23.83,41.27 l -29.63,17.11 0.4,-0.26 z"
-   style="fill:#84ddea"
-   id="path10" />             </g>             <g
-   transform="translate(216.062,984.098)"
-   id="g16">                 <path
-   d="m 790.407,1686.24 c -5.193,2.99 -9.69,7.34 -12.898,12.89 -9.647,16.71 -4.036,38.3 12.495,48.14 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.25 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.99 9.5,-7.29 12.65,-12.76 9.65,-16.71 4.04,-38.3 -12.49,-48.14 h 0.01 l 28.82,16.65 c 14.75,8.51 23.83,24.24 23.83,41.27 0,29.59 0,76.35 0,105.94 0,17.02 -9.08,32.76 -23.83,41.27 l -29.63,17.1 0.4,-0.25 z"
-   style="fill:#997bc8"
-   id="path14" /></g></g></g> <text
-   xml:space="preserve"
-   transform="translate(663.354,37.565425)"
-   id="text307"
-   style="font-size:4px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect309);display:inline;fill:#006400;stroke:#006400;stroke-width:2.66667" /><g
-   aria-label="Helix"
-   transform="matrix(1.3113898,0,0,1.3113898,142.0244,48.21073)"
-   id="text445"
-   style="font-size:4px;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect447);display:inline;fill:#2a292f;stroke:#2a292f;stroke-width:2.66687"><path
-     d="m 1242.0723,515.10828 h -60.4 v -123.2 h -113.2 v 123.2 h -60.4 v -285.6 h 60.4 v 112 h 113.2 v -112 h 60.4 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
-     id="path14794" /><path
-     d="m 1399.272,292.70828 q 30.4,0 52,11.6 22,11.6 34,33.6 12,22 12,54 v 28.8 h -140.8 q 0.8,25.2 14.8,39.6 14.4,14.4 39.6,14.4 21.2,0 38.4,-4 17.2,-4.4 35.6,-13.2 v 46 q -16,8 -34,11.6 -17.6,4 -42.8,4 -32.8,0 -58,-12 -25.2,-12.4 -39.6,-37.2 -14.4,-24.8 -14.4,-62.4 0,-38.4 12.8,-63.6 13.2,-25.6 36.4,-38.4 23.2,-12.8 54,-12.8 z m 0.4,42.4 q -17.2,0 -28.8,11.2 -11.2,11.2 -13.2,34.8 h 83.6 q 0,-13.2 -4.8,-23.6 -4.4,-10.4 -13.6,-16.4 -9.2,-6 -23.2,-6 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
-     id="path14796" /><path
-     d="m 1605.2719,515.10828 h -59.6 v -304 h 59.6 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
-     id="path14798" /><path
-     d="m 1727.272,296.70828 v 218.4 h -59.6 v -218.4 z m -29.6,-85.6 q 13.2,0 22.8,6.4 9.6,6 9.6,22.8 0,16.4 -9.6,22.8 -9.6,6.4 -22.8,6.4 -13.6,0 -23.2,-6.4 -9.2,-6.4 -9.2,-22.8 0,-16.8 9.2,-22.8 9.6,-6.4 23.2,-6.4 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
-     id="path14800" /><path
-     d="m 1834.4721,403.50828 -70.4,-106.8 h 67.6 l 42.4,69.6 42.8,-69.6 h 67.6 l -71.2,106.8 74.4,111.6 h -67.6 l -46,-74.8 -46,74.8 h -67.6 z"
-     style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
-     id="path14802" /></g><text
-   xml:space="preserve"
-   transform="translate(663.38,37.570044)"
-   id="text14661"
-   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:997.723px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, @wght=700';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variation-settings:'wght' 700;white-space:pre;shape-inside:url(#rect14663);display:inline;fill:#2a292f;fill-opacity:1;stroke:#2a292f;stroke-width:6.652;stroke-dasharray:none;stroke-opacity:1" /></svg>
+	version="1.1"
+	xml:space="preserve"
+	style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+	viewBox="663.38 37.57 2087.006 903.71997"
+	id="svg22"
+	sodipodi:docname="logo_light.svg"
+	width="2087.0059"
+	height="903.71997"
+	inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+	xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+	xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:svg="http://www.w3.org/2000/svg">
+
+<defs id="defs26">
+	<rect
+		x="713.02588"
+		y="-304.32538"
+		width="3615.2336"
+		height="1864.7544"
+		id="rect14663" />
+	<rect
+		x="972.073"
+		y="151.15895"
+		width="2140.9646"
+		height="684.86273"
+		id="rect447" />
+	<rect
+		x="897.0401"
+		y="217.45384"
+		width="837.72321"
+		height="631.59924"
+		id="rect435" />
+	<rect
+		x="825.67834"
+		y="157.61452"
+		width="1496.2448"
+		height="861.45544"
+		id="rect429" />
+	<rect
+		x="798.3819"
+		y="-42.157242"
+		width="2236.0837"
+		height="945.90723"
+		id="rect315" />
+	<rect
+		x="661.30237"
+		y="48.087799"
+		width="769.15619"
+		height="828.46844"
+		id="rect309" />
+</defs>
+<sodipodi:namedview
+	id="namedview24"
+	pagecolor="#ffffff"
+	bordercolor="#000000"
+	borderopacity="0.25"
+	inkscape:showpageshadow="2"
+	inkscape:pageopacity="0.0"
+	inkscape:pagecheckerboard="0"
+	inkscape:deskcolor="#d1d1d1"
+	showgrid="false"
+	inkscape:zoom="0.28409405"
+	inkscape:cx="1904.2989"
+	inkscape:cy="633.59299"
+	inkscape:window-width="1908"
+	inkscape:window-height="2075"
+	inkscape:window-x="26"
+	inkscape:window-y="23"
+	inkscape:window-maximized="0"
+	inkscape:current-layer="svg22" />
+<g
+	transform="translate(-31352.726,-1817.2547)"
+	id="g20">
+	<g
+		transform="translate(31062.7,-20.8972)"
+		id="g18">
+		<g
+			transform="translate(-130.173,0.00185558)"
+			id="g4">
+			<path
+				d="m 1083.58,1875.72 551.48,318.4 c 14.74,8.51 23.82,24.25 23.82,41.27 0,29.59 0,76.35 0,105.94 0,8.51 -2.27,16.7 -6.38,23.83 0,0 -437.8,-252.76 -545.3,-314.83 -14.62,-8.44 -23.62,-24.04 -23.62,-40.92 0,-45.91 0,-133.69 0,-133.69 z"
+				style="fill:#706bc8"
+				id="path2" />
+		</g>
+		<g
+			transform="translate(-130.173,0.00185558)"
+			id="g8">
+			<path
+				d="m 1635.26,2604.84 c 14.62,8.44 23.62,24.03 23.62,40.91 0,45.92 0,133.69 0,133.69 l -551.47,-318.39 c -14.75,-8.52 -23.83,-24.25 -23.83,-41.27 0,-29.59 0,-76.36 0,-105.94 0,-8.52 2.27,-16.71 6.38,-23.83 0,0 437.8,252.76 545.3,314.83 z"
+				style="fill:#55c5e4"
+				id="path6" />
+		</g>
+		<g
+			transform="translate(216.062,984.098)"
+			id="g12">
+			<path
+				d="m 790.407,1432.56 c -5.193,2.99 -9.69,7.34 -12.898,12.9 -9.647,16.7 -4.036,38.3 12.495,48.13 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.24 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.983 9.5,-7.286 12.65,-12.756 9.65,-16.708 4.04,-38.3 -12.49,-48.137 h 0.01 l 28.82,16.642 c 14.75,8.513 23.83,24.246 23.83,41.273 0,29.588 0,76.348 0,105.938 0,17.03 -9.08,32.76 -23.83,41.27 l -29.63,17.11 0.4,-0.26 z"
+				style="fill:#84ddea"
+				id="path10" />
+		</g>
+		<g
+			transform="translate(216.062,984.098)"
+			id="g16">
+			<path
+				d="m 790.407,1686.24 c -5.193,2.99 -9.69,7.34 -12.898,12.89 -9.647,16.71 -4.036,38.3 12.495,48.14 h -0.006 l -28.825,-16.64 c -14.746,-8.51 -23.829,-24.25 -23.829,-41.27 0,-29.59 0,-76.35 0,-105.94 0,-17.03 9.083,-32.76 23.829,-41.27 l 498.417,-287.73 0.24,-0.14 c 5.09,-2.99 9.5,-7.29 12.65,-12.76 9.65,-16.71 4.04,-38.3 -12.49,-48.14 h 0.01 l 28.82,16.65 c 14.75,8.51 23.83,24.24 23.83,41.27 0,29.59 0,76.35 0,105.94 0,17.02 -9.08,32.76 -23.83,41.27 l -29.63,17.1 0.4,-0.25 z"
+				style="fill:#997bc8"
+				id="path14" />
+		</g>
+	</g>
+</g>
+
+<text
+	xml:space="preserve"
+	transform="translate(663.354,37.565425)"
+	id="text307"
+	style="font-size:4px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect309);display:inline;fill:#006400;stroke:#006400;stroke-width:2.66667" />
+
+<g
+	aria-label="Helix"
+	transform="matrix(1.3113898,0,0,1.3113898,142.0244,48.21073)"
+	id="text445"
+	style="font-size:4px;-inkscape-font-specification:'sans-serif, Normal';white-space:pre;shape-inside:url(#rect447);display:inline;fill:#2a292f;stroke:#2a292f;stroke-width:2.66687">
+	<path
+		d="m 1242.0723,515.10828 h -60.4 v -123.2 h -113.2 v 123.2 h -60.4 v -285.6 h 60.4 v 112 h 113.2 v -112 h 60.4 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
+		id="path14794" />
+	<path
+		d="m 1399.272,292.70828 q 30.4,0 52,11.6 22,11.6 34,33.6 12,22 12,54 v 28.8 h -140.8 q 0.8,25.2 14.8,39.6 14.4,14.4 39.6,14.4 21.2,0 38.4,-4 17.2,-4.4 35.6,-13.2 v 46 q -16,8 -34,11.6 -17.6,4 -42.8,4 -32.8,0 -58,-12 -25.2,-12.4 -39.6,-37.2 -14.4,-24.8 -14.4,-62.4 0,-38.4 12.8,-63.6 13.2,-25.6 36.4,-38.4 23.2,-12.8 54,-12.8 z m 0.4,42.4 q -17.2,0 -28.8,11.2 -11.2,11.2 -13.2,34.8 h 83.6 q 0,-13.2 -4.8,-23.6 -4.4,-10.4 -13.6,-16.4 -9.2,-6 -23.2,-6 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
+		id="path14796" />
+	<path
+		d="m 1605.2719,515.10828 h -59.6 v -304 h 59.6 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
+		id="path14798" />
+	<path
+		d="m 1727.272,296.70828 v 218.4 h -59.6 v -218.4 z m -29.6,-85.6 q 13.2,0 22.8,6.4 9.6,6 9.6,22.8 0,16.4 -9.6,22.8 -9.6,6.4 -22.8,6.4 -13.6,0 -23.2,-6.4 -9.2,-6.4 -9.2,-22.8 0,-16.8 9.2,-22.8 9.6,-6.4 23.2,-6.4 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
+		id="path14800" />
+	<path
+		d="m 1834.4721,403.50828 -70.4,-106.8 h 67.6 l 42.4,69.6 42.8,-69.6 h 67.6 l -71.2,106.8 74.4,111.6 h -67.6 l -46,-74.8 -46,74.8 h -67.6 z"
+		style="font-size:400px;-inkscape-font-specification:'sans-serif, @wght=700';font-variation-settings:'wght' 700"
+		id="path14802" />
+</g>
+
+<text
+	xml:space="preserve"
+	transform="translate(663.38,37.570044)"
+	id="text14661"
+	style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:997.723px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, @wght=700';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variation-settings:'wght' 700;white-space:pre;shape-inside:url(#rect14663);display:inline;fill:#2a292f;fill-opacity:1;stroke:#2a292f;stroke-width:6.652;stroke-dasharray:none;stroke-opacity:1" />
+
+</svg>


### PR DESCRIPTION
#### chore(logo_dark): Pretty to reduce size by 323B ...
  * Current size:  6,930 B
  * Original size: 7,253 B
  * Add tab indentation (instead of 2/4 spaces)
  * Pretty Print by hand

#### chore(logo_light): Pretty to reduce size by 322B ...
  * Current size:  6,599 B
  * Original size: 6,922 B
  * Add tab indentation (instead of 2/4 spaces)
  * Pretty Print by hand